### PR TITLE
Add win-arm64 build support

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,6 +14,12 @@ jobs:
         build_workspace_dir: D:\\bld\\
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
+      win_arm64_:
+        CONFIG: win_arm64_
+        UPLOAD_PACKAGES: 'True'
+        build_workspace_dir: C:\\bld\\
+        store_build_artifacts: false
+        tools_install_dir: C:\Miniforge
   timeoutInMinutes: 360
   variables:
     UPLOAD_TEMP: D:\\tmp

--- a/.ci_support/win_arm64_.yaml
+++ b/.ci_support/win_arm64_.yaml
@@ -1,0 +1,10 @@
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+rust_compiler:
+- rust
+target_platform:
+- win-arm64

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -9,4 +9,5 @@ conda_forge_output_validation: true
 build_platform:
   linux_aarch64: linux_64
   osx_arm64: osx_64
+  win_arm64: win_64
 test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -53,6 +53,12 @@ description = "Build pixi-build-rust-feedstock with variant win_64_ directly (wi
 [tasks."inspect-win_64_"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_.yaml"
 description = "List contents of pixi-build-rust-feedstock packages built for variant win_64_"
+[tasks."build-win_arm64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_arm64_.yaml"
+description = "Build pixi-build-rust-feedstock with variant win_arm64_ directly (without setup scripts)"
+[tasks."inspect-win_arm64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_arm64_.yaml"
+description = "List contents of pixi-build-rust-feedstock packages built for variant win_arm64_"
 
 [feature.smithy.dependencies]
 conda-smithy = "*"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -48,14 +48,17 @@ requirements:
   - cargo-bundle-licenses
   - cargo-auditable
   host:
-  - pkg-config
+  - if: target_platform != 'win-arm64'
+    then: pkg-config
   - if: unix
     then: openssl
   run:
   - pixi-build-api-version >=4,<5
 
 tests:
-- script: ${{ name }} --help
+- script:
+  - if: build_platform == target_platform
+    then: ${{ name }} --help
 - package_contents:
     bin:
     - ${{ name }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,6 +17,9 @@ build:
   number: 0
   script:
     env:
+      # Use cmake to build aws-lc-sys, because conda's CFLAGS inject -O2 which
+      # overrides the -O0 required by jitterentropy-base.c, causing a build failure.
+      AWS_LC_SYS_CMAKE_BUILDER: "1"
       CARGO_PROFILE_RELEASE_STRIP: symbols
       CARGO_PROFILE_RELEASE_LTO: fat
     content:
@@ -45,6 +48,9 @@ requirements:
   build:
   - ${{ compiler("rust") }}
   - ${{ stdlib("c") }}
+  # for building aws-lc-sys
+  - cmake
+  - ninja
   - cargo-bundle-licenses
   - cargo-auditable
   host:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -32,6 +32,11 @@ build:
     - if: unix
       then:
       - export OPENSSL_DIR="$PREFIX"
+    - if: linux
+      then:
+        # aws-lc-sys' cmake builder defaults to the "Unix Makefiles" generator, but the
+        # Linux build environment has no make; use the ninja generator instead.
+      - export CMAKE_GENERATOR=Ninja
     - if: win
       then:
       - set CARGO_HOME=C:\.cargo


### PR DESCRIPTION
Adds experimental `win-arm64` (Windows ARM64) cross-compilation support, cross-built from `win-64`.

Changes:
- `conda-forge.yml`: add `win_arm64: win_64` to `build_platform`
- `recipe.yaml`: guard `pkg-config` host dep with `target_platform != 'win-arm64'` (not available for that target)
- `recipe.yaml`: only run the `--help` script test when `build_platform == target_platform` (cross-built arm64 binary can't run on the win-64 builder)

Mirrors the win-arm64 enablement already present in pixi-build-python-feedstock.

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Re-rendered with the latest conda-smithy
- [x] Ensured the license file is being packaged